### PR TITLE
Fix: Remove unnecessary whitespace from .mskd-submit-btn

### DIFF
--- a/public/partials/subscribe-form.php
+++ b/public/partials/subscribe-form.php
@@ -31,9 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 
 		<div class="mskd-form-row">
-			<button type="submit" class="mskd-submit-btn">
-				<?php _e( 'Subscribe', 'mail-system-by-katsarov-design' ); ?>
-			</button>
+			<button type="submit" class="mskd-submit-btn"><?php _e( 'Subscribe', 'mail-system-by-katsarov-design' ); ?></button>
 		</div>
 
 		<div class="mskd-form-message" style="display: none;"></div>


### PR DESCRIPTION
Removes extra whitespace/line breaks from inside the submit button element in the subscribe form.

The button element had the PHP translation call on separate lines with indentation, which created unnecessary whitespace in the rendered HTML output.

**Before:**
```php
<button type="submit" class="mskd-submit-btn">
    <?php _e( 'Subscribe', 'mail-system-by-katsarov-design' ); ?>
</button>
```

**After:**
```php
<button type="submit" class="mskd-submit-btn"><?php _e( 'Subscribe', 'mail-system-by-katsarov-design' ); ?></button>
```