### PR TITLE
Fix #34: Set up GitHub Pages with bilingual homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,341 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mail System by Katsarov Design - WordPress Email Newsletter Plugin</title>
+    <meta name="description" content="A powerful WordPress plugin for email newsletter management with subscribers, lists, and sending queue. Supports English, Bulgarian, and German.">
+    <link rel="stylesheet" href="styles.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <div class="container">
+            <div class="header-content">
+                <div class="logo">
+                    <svg class="logo-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
+                        <polyline points="22,6 12,13 2,6"></polyline>
+                    </svg>
+                    <span class="logo-text">Mail System</span>
+                </div>
+                <nav class="nav">
+                    <a href="#features" data-en="Features" data-bg="Функции">Features</a>
+                    <a href="#installation" data-en="Installation" data-bg="Инсталация">Installation</a>
+                    <a href="#docs" data-en="Documentation" data-bg="Документация">Documentation</a>
+                    <a href="https://github.com/katsar0v/mail-system-by-katsarov-design" target="_blank" rel="noopener" class="nav-github">
+                        <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
+                            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                        </svg>
+                    </a>
+                    <button class="lang-switcher" id="langSwitcher" aria-label="Switch language">
+                        <span class="lang-current">EN</span>
+                    </button>
+                </nav>
+                <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Toggle menu">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <!-- Hero Section -->
+        <section class="hero">
+            <div class="container">
+                <div class="hero-content">
+                    <div class="badges">
+                        <span class="badge badge-wp">WordPress 5.0+</span>
+                        <span class="badge badge-php">PHP 7.4+</span>
+                        <span class="badge badge-license">GPL v2</span>
+                    </div>
+                    <h1 data-en="Mail System by Katsarov Design" data-bg="Mail System от Katsarov Design">Mail System by Katsarov Design</h1>
+                    <p class="hero-description" data-en="A powerful WordPress plugin for email newsletter management with subscribers, lists, and sending queue. Supports English, Bulgarian, and German interfaces." data-bg="Мощен WordPress плъгин за управление на имейл бюлетини с абонати, списъци и опашка за изпращане. Поддържа английски, български и немски интерфейс.">A powerful WordPress plugin for email newsletter management with subscribers, lists, and sending queue. Supports English, Bulgarian, and German interfaces.</p>
+                    <div class="hero-actions">
+                        <a href="https://github.com/katsar0v/mail-system-by-katsarov-design/releases" class="btn btn-primary" data-en="Download Latest Release" data-bg="Изтегли последната версия">Download Latest Release</a>
+                        <a href="https://github.com/katsar0v/mail-system-by-katsarov-design" class="btn btn-secondary" data-en="View on GitHub" data-bg="Виж в GitHub">View on GitHub</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Features Section -->
+        <section class="features" id="features">
+            <div class="container">
+                <h2 data-en="Key Features" data-bg="Основни функции">Key Features</h2>
+                <div class="features-grid">
+                    <div class="feature-card">
+                        <div class="feature-icon">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                                <circle cx="9" cy="7" r="4"></circle>
+                                <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+                                <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+                            </svg>
+                        </div>
+                        <h3 data-en="Subscriber Management" data-bg="Управление на абонати">Subscriber Management</h3>
+                        <p data-en="Add, edit, and delete subscribers with different statuses: Active, Inactive, Unsubscribed." data-bg="Добавяне, редактиране и изтриване на абонати с различни статуси: Активен, Неактивен, Отписан.">Add, edit, and delete subscribers with different statuses: Active, Inactive, Unsubscribed.</p>
+                    </div>
+                    <div class="feature-card">
+                        <div class="feature-icon">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <line x1="8" y1="6" x2="21" y2="6"></line>
+                                <line x1="8" y1="12" x2="21" y2="12"></line>
+                                <line x1="8" y1="18" x2="21" y2="18"></line>
+                                <line x1="3" y1="6" x2="3.01" y2="6"></line>
+                                <line x1="3" y1="12" x2="3.01" y2="12"></line>
+                                <line x1="3" y1="18" x2="3.01" y2="18"></line>
+                            </svg>
+                        </div>
+                        <h3 data-en="Mailing Lists" data-bg="Пощенски списъци">Mailing Lists</h3>
+                        <p data-en="Organize your subscribers into different lists for targeted email campaigns." data-bg="Организирайте абонатите си в различни списъци за целенасочени имейл кампании.">Organize your subscribers into different lists for targeted email campaigns.</p>
+                    </div>
+                    <div class="feature-card">
+                        <div class="feature-icon">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <polyline points="16 16 12 12 8 16"></polyline>
+                                <line x1="12" y1="12" x2="12" y2="21"></line>
+                                <path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"></path>
+                                <polyline points="16 16 12 12 8 16"></polyline>
+                            </svg>
+                        </div>
+                        <h3 data-en="Import/Export" data-bg="Импорт/Експорт">Import/Export</h3>
+                        <p data-en="Import and export subscribers and lists via CSV or JSON formats." data-bg="Импортиране и експортиране на абонати и списъци чрез CSV или JSON формати.">Import and export subscribers and lists via CSV or JSON formats.</p>
+                    </div>
+                    <div class="feature-card">
+                        <div class="feature-icon">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+                                <line x1="16" y1="2" x2="16" y2="6"></line>
+                                <line x1="8" y1="2" x2="8" y2="6"></line>
+                                <line x1="3" y1="10" x2="21" y2="10"></line>
+                            </svg>
+                        </div>
+                        <h3 data-en="Sending Queue" data-bg="Опашка за изпращане">Sending Queue</h3>
+                        <p data-en="Emails are added to a queue and sent automatically via WP-Cron integration." data-bg="Имейлите се добавят в опашка и се изпращат автоматично чрез WP-Cron интеграция.">Emails are added to a queue and sent automatically via WP-Cron integration.</p>
+                    </div>
+                    <div class="feature-card">
+                        <div class="feature-icon">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <rect x="2" y="4" width="20" height="16" rx="2"></rect>
+                                <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"></path>
+                            </svg>
+                        </div>
+                        <h3 data-en="SMTP Support" data-bg="SMTP поддръжка">SMTP Support</h3>
+                        <p data-en="Configure an external SMTP server for reliable email delivery with SSL/TLS encryption." data-bg="Конфигурирайте външен SMTP сървър за надеждна доставка на имейли с SSL/TLS криптиране.">Configure an external SMTP server for reliable email delivery with SSL/TLS encryption.</p>
+                    </div>
+                    <div class="feature-card">
+                        <div class="feature-icon">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <circle cx="12" cy="12" r="10"></circle>
+                                <line x1="2" y1="12" x2="22" y2="12"></line>
+                                <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+                            </svg>
+                        </div>
+                        <h3 data-en="Multi-language Support" data-bg="Многоезична поддръжка">Multi-language Support</h3>
+                        <p data-en="Full internationalization with English, Bulgarian, and German interfaces." data-bg="Пълна интернационализация с английски, български и немски интерфейс.">Full internationalization with English, Bulgarian, and German interfaces.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Technical Specs Section -->
+        <section class="specs">
+            <div class="container">
+                <h2 data-en="Technical Specifications" data-bg="Технически спецификации">Technical Specifications</h2>
+                <div class="specs-grid">
+                    <div class="spec-item">
+                        <span class="spec-label" data-en="Sending Speed" data-bg="Скорост на изпращане">Sending Speed</span>
+                        <span class="spec-value" data-en="Configurable (default: 10 emails/min)" data-bg="Конфигурируема (по подразбиране: 10 имейла/мин)">Configurable (default: 10 emails/min)</span>
+                    </div>
+                    <div class="spec-item">
+                        <span class="spec-label" data-en="Sending Method" data-bg="Метод на изпращане">Sending Method</span>
+                        <span class="spec-value">wp_mail() / SMTP</span>
+                    </div>
+                    <div class="spec-item">
+                        <span class="spec-label" data-en="Supported Protocols" data-bg="Поддържани протоколи">Supported Protocols</span>
+                        <span class="spec-value">SSL, TLS (StartTLS)</span>
+                    </div>
+                    <div class="spec-item">
+                        <span class="spec-label" data-en="Minimum PHP Version" data-bg="Минимална PHP версия">Minimum PHP Version</span>
+                        <span class="spec-value">7.4</span>
+                    </div>
+                    <div class="spec-item">
+                        <span class="spec-label" data-en="Minimum WP Version" data-bg="Минимална WP версия">Minimum WP Version</span>
+                        <span class="spec-value">5.0</span>
+                    </div>
+                    <div class="spec-item">
+                        <span class="spec-label" data-en="Database Tables" data-bg="Таблици в базата данни">Database Tables</span>
+                        <span class="spec-value">4</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Installation Section -->
+        <section class="installation" id="installation">
+            <div class="container">
+                <h2 data-en="Installation" data-bg="Инсталация">Installation</h2>
+                <div class="installation-steps">
+                    <div class="step">
+                        <span class="step-number">1</span>
+                        <div class="step-content">
+                            <h3 data-en="Download the Plugin" data-bg="Изтеглете плъгина">Download the Plugin</h3>
+                            <p data-en="Download the latest release from GitHub or clone the repository." data-bg="Изтеглете последната версия от GitHub или клонирайте хранилището.">Download the latest release from GitHub or clone the repository.</p>
+                        </div>
+                    </div>
+                    <div class="step">
+                        <span class="step-number">2</span>
+                        <div class="step-content">
+                            <h3 data-en="Upload to WordPress" data-bg="Качете в WordPress">Upload to WordPress</h3>
+                            <p data-en="Upload the plugin folder to /wp-content/plugins/ directory." data-bg="Качете папката на плъгина в директория /wp-content/plugins/.">Upload the plugin folder to /wp-content/plugins/ directory.</p>
+                        </div>
+                    </div>
+                    <div class="step">
+                        <span class="step-number">3</span>
+                        <div class="step-content">
+                            <h3 data-en="Activate the Plugin" data-bg="Активирайте плъгина">Activate the Plugin</h3>
+                            <p data-en="Activate the plugin from the 'Plugins' menu in WordPress admin." data-bg="Активирайте плъгина от менюто 'Плъгини' в WordPress администрацията.">Activate the plugin from the 'Plugins' menu in WordPress admin.</p>
+                        </div>
+                    </div>
+                    <div class="step">
+                        <span class="step-number">4</span>
+                        <div class="step-content">
+                            <h3 data-en="Configure Settings" data-bg="Конфигурирайте настройките">Configure Settings</h3>
+                            <p data-en="Go to 'Emails' menu to configure SMTP and start managing your newsletters." data-bg="Отидете в менюто 'Имейли', за да конфигурирате SMTP и да започнете да управлявате бюлетините си.">Go to 'Emails' menu to configure SMTP and start managing your newsletters.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="installation-note">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <circle cx="12" cy="12" r="10"></circle>
+                        <line x1="12" y1="16" x2="12" y2="12"></line>
+                        <line x1="12" y1="8" x2="12.01" y2="8"></line>
+                    </svg>
+                    <p data-en="No Composer or vendor directory required. The plugin works out of the box." data-bg="Не е необходим Composer или vendor директория. Плъгинът работи веднага след инсталиране.">No Composer or vendor directory required. The plugin works out of the box.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Placeholders Section -->
+        <section class="placeholders">
+            <div class="container">
+                <h2 data-en="Email Placeholders" data-bg="Плейсхолдъри за имейли">Email Placeholders</h2>
+                <p class="section-description" data-en="Use these placeholders in your email templates for personalized content:" data-bg="Използвайте тези плейсхолдъри в шаблоните за имейли за персонализирано съдържание:">Use these placeholders in your email templates for personalized content:</p>
+                <div class="placeholders-grid">
+                    <div class="placeholder-item">
+                        <code>{first_name}</code>
+                        <span data-en="Subscriber's first name" data-bg="Име на абоната">Subscriber's first name</span>
+                    </div>
+                    <div class="placeholder-item">
+                        <code>{last_name}</code>
+                        <span data-en="Subscriber's last name" data-bg="Фамилия на абоната">Subscriber's last name</span>
+                    </div>
+                    <div class="placeholder-item">
+                        <code>{email}</code>
+                        <span data-en="Subscriber's email" data-bg="Имейл на абоната">Subscriber's email</span>
+                    </div>
+                    <div class="placeholder-item">
+                        <code>{unsubscribe_link}</code>
+                        <span data-en="Unsubscribe link (HTML)" data-bg="Линк за отписване (HTML)">Unsubscribe link (HTML)</span>
+                    </div>
+                    <div class="placeholder-item">
+                        <code>{unsubscribe_url}</code>
+                        <span data-en="Unsubscribe URL (plain)" data-bg="URL за отписване (само текст)">Unsubscribe URL (plain)</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Documentation Section -->
+        <section class="documentation" id="docs">
+            <div class="container">
+                <h2 data-en="Documentation" data-bg="Документация">Documentation</h2>
+                <div class="docs-grid">
+                    <a href="api-reference.md" class="doc-card">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                            <polyline points="14 2 14 8 20 8"></polyline>
+                            <line x1="16" y1="13" x2="8" y2="13"></line>
+                            <line x1="16" y1="17" x2="8" y2="17"></line>
+                            <polyline points="10 9 9 9 8 9"></polyline>
+                        </svg>
+                        <h3>API Reference</h3>
+                        <p data-en="Complete API documentation for developers" data-bg="Пълна API документация за разработчици">Complete API documentation for developers</p>
+                    </a>
+                    <a href="email-header-footer.md" class="doc-card">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <rect x="2" y="4" width="20" height="16" rx="2"></rect>
+                            <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"></path>
+                        </svg>
+                        <h3>Email Header/Footer</h3>
+                        <p data-en="Customize email templates with headers and footers" data-bg="Персонализирайте имейл шаблони с хедъри и футъри">Customize email templates with headers and footers</p>
+                    </a>
+                    <a href="scss-guidelines.md" class="doc-card">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M12 2L2 7l10 5 10-5-10-5z"></path>
+                            <path d="M2 17l10 5 10-5"></path>
+                            <path d="M2 12l10 5 10-5"></path>
+                        </svg>
+                        <h3>SCSS Guidelines</h3>
+                        <p data-en="Styling conventions and SCSS structure" data-bg="Конвенции за стилове и SCSS структура">Styling conventions and SCSS structure</p>
+                    </a>
+                    <a href="https://github.com/katsar0v/mail-system-by-katsarov-design/blob/main/README.md" class="doc-card" target="_blank" rel="noopener">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path>
+                            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path>
+                        </svg>
+                        <h3>README</h3>
+                        <p data-en="Full documentation and usage guide" data-bg="Пълна документация и ръководство за употреба">Full documentation and usage guide</p>
+                    </a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-brand">
+                    <div class="logo">
+                        <svg class="logo-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
+                            <polyline points="22,6 12,13 2,6"></polyline>
+                        </svg>
+                        <span class="logo-text">Mail System</span>
+                    </div>
+                    <p data-en="Email newsletter management for WordPress" data-bg="Управление на имейл бюлетини за WordPress">Email newsletter management for WordPress</p>
+                </div>
+                <div class="footer-links">
+                    <div class="footer-column">
+                        <h4 data-en="Resources" data-bg="Ресурси">Resources</h4>
+                        <a href="https://github.com/katsar0v/mail-system-by-katsarov-design" target="_blank" rel="noopener">GitHub</a>
+                        <a href="https://github.com/katsar0v/mail-system-by-katsarov-design/releases" target="_blank" rel="noopener" data-en="Releases" data-bg="Версии">Releases</a>
+                        <a href="https://github.com/katsar0v/mail-system-by-katsarov-design/issues" target="_blank" rel="noopener" data-en="Issues" data-bg="Проблеми">Issues</a>
+                    </div>
+                    <div class="footer-column">
+                        <h4 data-en="Documentation" data-bg="Документация">Documentation</h4>
+                        <a href="api-reference.md">API Reference</a>
+                        <a href="email-header-footer.md">Email Header/Footer</a>
+                        <a href="scss-guidelines.md">SCSS Guidelines</a>
+                    </div>
+                    <div class="footer-column">
+                        <h4 data-en="Author" data-bg="Автор">Author</h4>
+                        <a href="https://katsarov.design" target="_blank" rel="noopener">Katsarov Design</a>
+                    </div>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p data-en="Licensed under GPL v2 or later" data-bg="Лицензиран под GPL v2 или по-нова версия">Licensed under GPL v2 or later</p>
+                <p>© 2025 Katsarov Design</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,172 @@
+/**
+ * Mail System by Katsarov Design - GitHub Pages Scripts
+ * 
+ * Language switching functionality with localStorage persistence
+ */
+
+(function() {
+    'use strict';
+
+    // Language configuration
+    const STORAGE_KEY = 'mskd-lang';
+    const DEFAULT_LANG = 'en';
+    const SUPPORTED_LANGS = ['en', 'bg'];
+
+    // Language display names
+    const LANG_NAMES = {
+        en: 'EN',
+        bg: 'BG'
+    };
+
+    /**
+     * Get the current language from localStorage or default
+     * @returns {string} Current language code
+     */
+    function getCurrentLang() {
+        const storedLang = localStorage.getItem(STORAGE_KEY);
+        if (storedLang && SUPPORTED_LANGS.includes(storedLang)) {
+            return storedLang;
+        }
+        
+        // Try to detect from browser language
+        const browserLang = navigator.language.split('-')[0];
+        if (SUPPORTED_LANGS.includes(browserLang)) {
+            return browserLang;
+        }
+        
+        return DEFAULT_LANG;
+    }
+
+    /**
+     * Save language preference to localStorage
+     * @param {string} lang - Language code to save
+     */
+    function saveLang(lang) {
+        localStorage.setItem(STORAGE_KEY, lang);
+    }
+
+    /**
+     * Update all translatable elements on the page
+     * @param {string} lang - Target language code
+     */
+    function updatePageContent(lang) {
+        // Update all elements with data-en and data-bg attributes
+        const elements = document.querySelectorAll('[data-en][data-bg]');
+        
+        elements.forEach(function(el) {
+            const text = el.getAttribute('data-' + lang);
+            if (text) {
+                el.textContent = text;
+            }
+        });
+
+        // Update the language switcher button
+        const langSwitcher = document.getElementById('langSwitcher');
+        if (langSwitcher) {
+            const langCurrent = langSwitcher.querySelector('.lang-current');
+            if (langCurrent) {
+                langCurrent.textContent = LANG_NAMES[lang];
+            }
+        }
+
+        // Update the html lang attribute
+        document.documentElement.lang = lang;
+    }
+
+    /**
+     * Get the next language in rotation
+     * @param {string} currentLang - Current language code
+     * @returns {string} Next language code
+     */
+    function getNextLang(currentLang) {
+        const currentIndex = SUPPORTED_LANGS.indexOf(currentLang);
+        const nextIndex = (currentIndex + 1) % SUPPORTED_LANGS.length;
+        return SUPPORTED_LANGS[nextIndex];
+    }
+
+    /**
+     * Toggle to the next language
+     */
+    function toggleLanguage() {
+        const currentLang = getCurrentLang();
+        const nextLang = getNextLang(currentLang);
+        
+        saveLang(nextLang);
+        updatePageContent(nextLang);
+    }
+
+    /**
+     * Initialize mobile menu toggle
+     */
+    function initMobileMenu() {
+        const menuToggle = document.getElementById('mobileMenuToggle');
+        const nav = document.querySelector('.nav');
+        
+        if (menuToggle && nav) {
+            menuToggle.addEventListener('click', function() {
+                nav.classList.toggle('active');
+                menuToggle.classList.toggle('active');
+            });
+
+            // Close menu when clicking on a link
+            nav.querySelectorAll('a').forEach(function(link) {
+                link.addEventListener('click', function() {
+                    nav.classList.remove('active');
+                    menuToggle.classList.remove('active');
+                });
+            });
+        }
+    }
+
+    /**
+     * Initialize smooth scroll for anchor links
+     */
+    function initSmoothScroll() {
+        document.querySelectorAll('a[href^="#"]').forEach(function(anchor) {
+            anchor.addEventListener('click', function(e) {
+                const targetId = this.getAttribute('href');
+                if (targetId === '#') return;
+                
+                const target = document.querySelector(targetId);
+                if (target) {
+                    e.preventDefault();
+                    const headerHeight = document.querySelector('.header').offsetHeight;
+                    const targetPosition = target.offsetTop - headerHeight - 20;
+                    
+                    window.scrollTo({
+                        top: targetPosition,
+                        behavior: 'smooth'
+                    });
+                }
+            });
+        });
+    }
+
+    /**
+     * Initialize everything when DOM is ready
+     */
+    function init() {
+        // Set initial language
+        const currentLang = getCurrentLang();
+        updatePageContent(currentLang);
+
+        // Set up language switcher
+        const langSwitcher = document.getElementById('langSwitcher');
+        if (langSwitcher) {
+            langSwitcher.addEventListener('click', toggleLanguage);
+        }
+
+        // Initialize mobile menu
+        initMobileMenu();
+
+        // Initialize smooth scrolling
+        initSmoothScroll();
+    }
+
+    // Run initialization when DOM is ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,810 @@
+/* ==========================================================================
+   Mail System by Katsarov Design - GitHub Pages Styles
+   ========================================================================== */
+
+/* CSS Variables */
+:root {
+    /* Colors - matching WordPress admin styling */
+    --color-primary: #2271b1;
+    --color-primary-dark: #135e96;
+    --color-primary-light: #72aee6;
+    --color-secondary: #50575e;
+    --color-success: #00a32a;
+    --color-warning: #dba617;
+    --color-error: #d63638;
+    
+    /* Neutrals */
+    --color-white: #ffffff;
+    --color-gray-100: #f6f7f7;
+    --color-gray-200: #f0f0f1;
+    --color-gray-300: #dcdcde;
+    --color-gray-400: #c3c4c7;
+    --color-gray-500: #8c8f94;
+    --color-gray-600: #646970;
+    --color-gray-700: #3c434a;
+    --color-gray-800: #2c3338;
+    --color-gray-900: #1d2327;
+    
+    /* Typography */
+    --font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+    --font-size-xs: 0.75rem;
+    --font-size-sm: 0.875rem;
+    --font-size-base: 1rem;
+    --font-size-lg: 1.125rem;
+    --font-size-xl: 1.25rem;
+    --font-size-2xl: 1.5rem;
+    --font-size-3xl: 1.875rem;
+    --font-size-4xl: 2.25rem;
+    --font-size-5xl: 3rem;
+    
+    /* Spacing */
+    --spacing-1: 0.25rem;
+    --spacing-2: 0.5rem;
+    --spacing-3: 0.75rem;
+    --spacing-4: 1rem;
+    --spacing-5: 1.25rem;
+    --spacing-6: 1.5rem;
+    --spacing-8: 2rem;
+    --spacing-10: 2.5rem;
+    --spacing-12: 3rem;
+    --spacing-16: 4rem;
+    --spacing-20: 5rem;
+    
+    /* Border Radius */
+    --radius-sm: 4px;
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --radius-full: 9999px;
+    
+    /* Shadows */
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    
+    /* Transitions */
+    --transition-fast: 150ms ease;
+    --transition-base: 200ms ease;
+    --transition-slow: 300ms ease;
+    
+    /* Container */
+    --container-max-width: 1200px;
+}
+
+/* Reset */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    font-family: var(--font-family);
+    font-size: var(--font-size-base);
+    line-height: 1.6;
+    color: var(--color-gray-800);
+    background-color: var(--color-white);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+    color: var(--color-primary);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+}
+
+a:hover {
+    color: var(--color-primary-dark);
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+}
+
+/* Container */
+.container {
+    width: 100%;
+    max-width: var(--container-max-width);
+    margin: 0 auto;
+    padding: 0 var(--spacing-6);
+}
+
+/* ==========================================================================
+   Header
+   ========================================================================== */
+
+.header {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background-color: var(--color-white);
+    border-bottom: 1px solid var(--color-gray-200);
+    backdrop-filter: blur(8px);
+    background-color: rgba(255, 255, 255, 0.95);
+}
+
+.header-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 72px;
+}
+
+.logo {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-3);
+    color: var(--color-gray-900);
+    font-weight: 600;
+    font-size: var(--font-size-lg);
+}
+
+.logo-icon {
+    width: 32px;
+    height: 32px;
+    color: var(--color-primary);
+}
+
+.nav {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-8);
+}
+
+.nav a {
+    color: var(--color-gray-700);
+    font-weight: 500;
+    font-size: var(--font-size-sm);
+    transition: color var(--transition-fast);
+}
+
+.nav a:hover {
+    color: var(--color-primary);
+}
+
+.nav-github {
+    display: flex;
+    align-items: center;
+    padding: var(--spacing-2);
+    border-radius: var(--radius-md);
+    transition: background-color var(--transition-fast);
+}
+
+.nav-github:hover {
+    background-color: var(--color-gray-100);
+}
+
+.lang-switcher {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2);
+    padding: var(--spacing-2) var(--spacing-3);
+    background-color: var(--color-gray-100);
+    border: 1px solid var(--color-gray-300);
+    border-radius: var(--radius-full);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    color: var(--color-gray-700);
+    transition: all var(--transition-fast);
+}
+
+.lang-switcher:hover {
+    background-color: var(--color-gray-200);
+    border-color: var(--color-gray-400);
+}
+
+.mobile-menu-toggle {
+    display: none;
+    flex-direction: column;
+    gap: 5px;
+    padding: var(--spacing-2);
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+
+.mobile-menu-toggle span {
+    display: block;
+    width: 24px;
+    height: 2px;
+    background-color: var(--color-gray-700);
+    transition: all var(--transition-fast);
+}
+
+/* ==========================================================================
+   Hero Section
+   ========================================================================== */
+
+.hero {
+    padding: var(--spacing-20) 0;
+    background: linear-gradient(135deg, var(--color-gray-100) 0%, var(--color-white) 100%);
+}
+
+.hero-content {
+    max-width: 800px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.badges {
+    display: flex;
+    justify-content: center;
+    gap: var(--spacing-3);
+    margin-bottom: var(--spacing-6);
+    flex-wrap: wrap;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--spacing-1) var(--spacing-3);
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    border-radius: var(--radius-full);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.badge-wp {
+    background-color: #21759b;
+    color: var(--color-white);
+}
+
+.badge-php {
+    background-color: #777bb4;
+    color: var(--color-white);
+}
+
+.badge-license {
+    background-color: var(--color-success);
+    color: var(--color-white);
+}
+
+.hero h1 {
+    font-size: var(--font-size-4xl);
+    font-weight: 700;
+    color: var(--color-gray-900);
+    margin-bottom: var(--spacing-6);
+    line-height: 1.2;
+}
+
+.hero-description {
+    font-size: var(--font-size-xl);
+    color: var(--color-gray-600);
+    margin-bottom: var(--spacing-8);
+    line-height: 1.7;
+}
+
+.hero-actions {
+    display: flex;
+    justify-content: center;
+    gap: var(--spacing-4);
+    flex-wrap: wrap;
+}
+
+/* Buttons */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--spacing-3) var(--spacing-6);
+    font-family: inherit;
+    font-size: var(--font-size-base);
+    font-weight: 600;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: all var(--transition-fast);
+    border: 2px solid transparent;
+}
+
+.btn-primary {
+    background-color: var(--color-primary);
+    color: var(--color-white);
+    border-color: var(--color-primary);
+}
+
+.btn-primary:hover {
+    background-color: var(--color-primary-dark);
+    border-color: var(--color-primary-dark);
+    color: var(--color-white);
+}
+
+.btn-secondary {
+    background-color: var(--color-white);
+    color: var(--color-gray-700);
+    border-color: var(--color-gray-300);
+}
+
+.btn-secondary:hover {
+    background-color: var(--color-gray-100);
+    border-color: var(--color-gray-400);
+    color: var(--color-gray-800);
+}
+
+/* ==========================================================================
+   Features Section
+   ========================================================================== */
+
+.features {
+    padding: var(--spacing-20) 0;
+}
+
+.features h2 {
+    text-align: center;
+    font-size: var(--font-size-3xl);
+    font-weight: 700;
+    color: var(--color-gray-900);
+    margin-bottom: var(--spacing-12);
+}
+
+.features-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--spacing-8);
+}
+
+.feature-card {
+    padding: var(--spacing-8);
+    background-color: var(--color-white);
+    border: 1px solid var(--color-gray-200);
+    border-radius: var(--radius-lg);
+    transition: all var(--transition-base);
+}
+
+.feature-card:hover {
+    border-color: var(--color-primary-light);
+    box-shadow: var(--shadow-lg);
+    transform: translateY(-4px);
+}
+
+.feature-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    background-color: var(--color-gray-100);
+    border-radius: var(--radius-md);
+    margin-bottom: var(--spacing-5);
+}
+
+.feature-icon svg {
+    width: 28px;
+    height: 28px;
+    color: var(--color-primary);
+}
+
+.feature-card h3 {
+    font-size: var(--font-size-lg);
+    font-weight: 600;
+    color: var(--color-gray-900);
+    margin-bottom: var(--spacing-3);
+}
+
+.feature-card p {
+    font-size: var(--font-size-sm);
+    color: var(--color-gray-600);
+    line-height: 1.6;
+}
+
+/* ==========================================================================
+   Technical Specs Section
+   ========================================================================== */
+
+.specs {
+    padding: var(--spacing-20) 0;
+    background-color: var(--color-gray-900);
+}
+
+.specs h2 {
+    text-align: center;
+    font-size: var(--font-size-3xl);
+    font-weight: 700;
+    color: var(--color-white);
+    margin-bottom: var(--spacing-12);
+}
+
+.specs-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--spacing-6);
+}
+
+.spec-item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-2);
+    padding: var(--spacing-6);
+    background-color: var(--color-gray-800);
+    border-radius: var(--radius-md);
+    text-align: center;
+}
+
+.spec-label {
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    color: var(--color-gray-400);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.spec-value {
+    font-size: var(--font-size-lg);
+    font-weight: 600;
+    color: var(--color-white);
+}
+
+/* ==========================================================================
+   Installation Section
+   ========================================================================== */
+
+.installation {
+    padding: var(--spacing-20) 0;
+}
+
+.installation h2 {
+    text-align: center;
+    font-size: var(--font-size-3xl);
+    font-weight: 700;
+    color: var(--color-gray-900);
+    margin-bottom: var(--spacing-12);
+}
+
+.installation-steps {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: var(--spacing-6);
+    margin-bottom: var(--spacing-8);
+}
+
+.step {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.step-number {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    background-color: var(--color-primary);
+    color: var(--color-white);
+    font-size: var(--font-size-xl);
+    font-weight: 700;
+    border-radius: var(--radius-full);
+    margin-bottom: var(--spacing-4);
+}
+
+.step-content h3 {
+    font-size: var(--font-size-base);
+    font-weight: 600;
+    color: var(--color-gray-900);
+    margin-bottom: var(--spacing-2);
+}
+
+.step-content p {
+    font-size: var(--font-size-sm);
+    color: var(--color-gray-600);
+}
+
+.installation-note {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-3);
+    padding: var(--spacing-4) var(--spacing-6);
+    background-color: var(--color-gray-100);
+    border-radius: var(--radius-md);
+    color: var(--color-gray-700);
+}
+
+.installation-note svg {
+    width: 24px;
+    height: 24px;
+    color: var(--color-primary);
+    flex-shrink: 0;
+}
+
+.installation-note p {
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+}
+
+/* ==========================================================================
+   Placeholders Section
+   ========================================================================== */
+
+.placeholders {
+    padding: var(--spacing-20) 0;
+    background-color: var(--color-gray-100);
+}
+
+.placeholders h2 {
+    text-align: center;
+    font-size: var(--font-size-3xl);
+    font-weight: 700;
+    color: var(--color-gray-900);
+    margin-bottom: var(--spacing-4);
+}
+
+.section-description {
+    text-align: center;
+    font-size: var(--font-size-lg);
+    color: var(--color-gray-600);
+    margin-bottom: var(--spacing-10);
+    max-width: 600px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.placeholders-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: var(--spacing-4);
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.placeholder-item {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-4);
+    padding: var(--spacing-4) var(--spacing-5);
+    background-color: var(--color-white);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-gray-200);
+}
+
+.placeholder-item code {
+    padding: var(--spacing-1) var(--spacing-2);
+    background-color: var(--color-gray-100);
+    border-radius: var(--radius-sm);
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: var(--font-size-sm);
+    color: var(--color-primary-dark);
+    white-space: nowrap;
+}
+
+.placeholder-item span {
+    font-size: var(--font-size-sm);
+    color: var(--color-gray-600);
+}
+
+/* ==========================================================================
+   Documentation Section
+   ========================================================================== */
+
+.documentation {
+    padding: var(--spacing-20) 0;
+}
+
+.documentation h2 {
+    text-align: center;
+    font-size: var(--font-size-3xl);
+    font-weight: 700;
+    color: var(--color-gray-900);
+    margin-bottom: var(--spacing-12);
+}
+
+.docs-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: var(--spacing-6);
+}
+
+.doc-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: var(--spacing-8);
+    background-color: var(--color-white);
+    border: 1px solid var(--color-gray-200);
+    border-radius: var(--radius-lg);
+    text-align: center;
+    transition: all var(--transition-base);
+}
+
+.doc-card:hover {
+    border-color: var(--color-primary-light);
+    box-shadow: var(--shadow-md);
+    transform: translateY(-2px);
+}
+
+.doc-card svg {
+    width: 40px;
+    height: 40px;
+    color: var(--color-primary);
+    margin-bottom: var(--spacing-4);
+}
+
+.doc-card h3 {
+    font-size: var(--font-size-base);
+    font-weight: 600;
+    color: var(--color-gray-900);
+    margin-bottom: var(--spacing-2);
+}
+
+.doc-card p {
+    font-size: var(--font-size-sm);
+    color: var(--color-gray-600);
+}
+
+/* ==========================================================================
+   Footer
+   ========================================================================== */
+
+.footer {
+    padding: var(--spacing-16) 0 var(--spacing-8);
+    background-color: var(--color-gray-900);
+    color: var(--color-gray-300);
+}
+
+.footer-content {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    gap: var(--spacing-16);
+    margin-bottom: var(--spacing-12);
+}
+
+.footer-brand .logo {
+    color: var(--color-white);
+    margin-bottom: var(--spacing-4);
+}
+
+.footer-brand .logo-icon {
+    color: var(--color-primary-light);
+}
+
+.footer-brand p {
+    font-size: var(--font-size-sm);
+    color: var(--color-gray-400);
+}
+
+.footer-links {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--spacing-8);
+}
+
+.footer-column h4 {
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    color: var(--color-white);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: var(--spacing-4);
+}
+
+.footer-column a {
+    display: block;
+    font-size: var(--font-size-sm);
+    color: var(--color-gray-400);
+    padding: var(--spacing-1) 0;
+    transition: color var(--transition-fast);
+}
+
+.footer-column a:hover {
+    color: var(--color-white);
+}
+
+.footer-bottom {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-top: var(--spacing-8);
+    border-top: 1px solid var(--color-gray-800);
+    font-size: var(--font-size-sm);
+    color: var(--color-gray-500);
+}
+
+/* ==========================================================================
+   Responsive Design
+   ========================================================================== */
+
+@media (max-width: 1024px) {
+    .features-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    
+    .specs-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    
+    .installation-steps {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    
+    .docs-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    
+    .footer-content {
+        grid-template-columns: 1fr;
+        gap: var(--spacing-10);
+    }
+}
+
+@media (max-width: 768px) {
+    .nav {
+        display: none;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        flex-direction: column;
+        padding: var(--spacing-4) var(--spacing-6);
+        background-color: var(--color-white);
+        border-bottom: 1px solid var(--color-gray-200);
+        gap: var(--spacing-4);
+    }
+    
+    .nav.active {
+        display: flex;
+    }
+    
+    .mobile-menu-toggle {
+        display: flex;
+    }
+    
+    .hero {
+        padding: var(--spacing-12) 0;
+    }
+    
+    .hero h1 {
+        font-size: var(--font-size-3xl);
+    }
+    
+    .hero-description {
+        font-size: var(--font-size-lg);
+    }
+    
+    .features-grid,
+    .specs-grid,
+    .docs-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .installation-steps {
+        grid-template-columns: 1fr;
+        gap: var(--spacing-8);
+    }
+    
+    .footer-links {
+        grid-template-columns: 1fr;
+        gap: var(--spacing-6);
+    }
+    
+    .footer-bottom {
+        flex-direction: column;
+        gap: var(--spacing-2);
+        text-align: center;
+    }
+}
+
+@media (max-width: 480px) {
+    .badges {
+        flex-direction: column;
+        align-items: center;
+    }
+    
+    .hero-actions {
+        flex-direction: column;
+    }
+    
+    .btn {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary

This PR sets up GitHub Pages for the repository with a custom-built project website as requested in #34.

## Changes

### New Files in `docs/`

| File | Description |
|------|-------------|
| `index.html` | Main homepage with project overview and bilingual content |
| `styles.css` | Responsive styling matching WordPress admin branding |
| `script.js` | Language switcher with localStorage persistence |

### Features Implemented

- ✅ **Homepage with project overview** - Hero section, features grid, technical specs, installation guide
- ✅ **Language switcher (EN/BG)** - Toggle button in header with localStorage persistence
- ✅ **Bilingual content** - All text content available in English and Bulgarian
- ✅ **Documentation links** - Links to existing markdown docs (api-reference.md, email-header-footer.md, scss-guidelines.md)
- ✅ **Responsive design** - Mobile-friendly with hamburger menu
- ✅ **WordPress admin styling** - Uses plugin's color scheme (`#2271b1` primary)

### Sections Included

1. **Header** - Logo, navigation, GitHub link, language switcher
2. **Hero** - Badges, title, description, CTAs
3. **Features** - 6 feature cards with icons
4. **Technical Specifications** - Key specs in dark theme section
5. **Installation** - 4-step visual guide
6. **Email Placeholders** - Reference for available placeholders
7. **Documentation** - Links to markdown docs
8. **Footer** - Resources, documentation links, author info

## Post-Merge Action Required

After merging, GitHub Pages needs to be enabled in repository settings:

1. Go to **Settings → Pages**
2. Set Source to **Deploy from a branch**
3. Select branch: **main** and folder: **/docs**
4. Click **Save**

The site will then be accessible at: https://katsar0v.github.io/mail-system-by-katsarov-design/

## Screenshots

The homepage includes:
- Clean, modern design
- Smooth scroll navigation
- Hover effects on cards
- Mobile hamburger menu
- Language toggle that remembers preference

## Testing

- Open `docs/index.html` locally in a browser
- Click the EN/BG toggle to verify language switching
- Resize browser to test responsive breakpoints
- Test mobile menu on narrow screens

Closes #34