### PR TITLE
Fix issue #64: Implement batch processing for email queue and subscriber operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BCC Display in Queue Details**
   - BCC recipients are now visible in the campaign details page when viewing queue items
   - Only displayed when BCC is configured for the campaign
+- **Batch Processing for Email Queue Operations**
+  - Added `batch_queue_subscribers()` method to Email_Service for chunking large subscriber lists
+  - Added `process_subscriber_chunk()` to handle individual chunks efficiently
+  - Added `batch_insert_queue_items()` for optimized database inserts
+  - Added `batch_get_or_create()` method to Subscriber_Service for bulk subscriber operations
+  - Added `batch_create()` for creating multiple subscribers at once
+  - Added `batch_get_by_ids()` for retrieving multiple subscribers by IDs
+  - Comprehensive unit tests for batch processing functionality
+
+### Performance
+- Improved performance when handling large email campaigns through batch processing
+- Reduced database queries by batching operations
+- Prevents memory issues when processing large subscriber lists
 
 ---
 

--- a/includes/Services/class-email-service.php
+++ b/includes/Services/class-email-service.php
@@ -129,44 +129,44 @@ class Email_Service {
 	}
 
 	/**
-		* Batch queue subscribers for a campaign with chunking to handle large lists.
-		*
-		* @param int    $campaign_id   Campaign ID.
-		* @param array  $subscribers   Array of subscriber objects.
-		* @param string $subject       Email subject.
-		* @param string $body          Email body.
-		* @param string $scheduled_at  MySQL datetime for scheduling.
-		* @param int    $chunk_size    Number of subscribers to process in each chunk. Default 500.
-		* @return int Number of subscribers queued.
-		*/
+	 * Batch queue subscribers for a campaign with chunking to handle large lists.
+	 *
+	 * @param int    $campaign_id   Campaign ID.
+	 * @param array  $subscribers   Array of subscriber objects.
+	 * @param string $subject       Email subject.
+	 * @param string $body          Email body.
+	 * @param string $scheduled_at  MySQL datetime for scheduling.
+	 * @param int    $chunk_size    Number of subscribers to process in each chunk. Default 500.
+	 * @return int Number of subscribers queued.
+	 */
 	private function batch_queue_subscribers( int $campaign_id, array $subscribers, string $subject, string $body, string $scheduled_at, int $chunk_size = 500 ): int {
 		if ( empty( $subscribers ) ) {
 			return 0;
 		}
 
 		$queued_total = 0;
-		$chunks = array_chunk( $subscribers, $chunk_size );
+		$chunks       = array_chunk( $subscribers, $chunk_size );
 
 		foreach ( $chunks as $chunk ) {
 			$queued_in_chunk = $this->process_subscriber_chunk( $campaign_id, $chunk, $subject, $body, $scheduled_at );
-			$queued_total += $queued_in_chunk;
+			$queued_total   += $queued_in_chunk;
 		}
 
 		return $queued_total;
 	}
 
 	/**
-		* Process a chunk of subscribers for queueing.
-		*
-		* @param int    $campaign_id  Campaign ID.
-		* @param array  $chunk        Array of subscriber objects.
-		* @param string $subject      Email subject.
-		* @param string $body         Email body.
-		* @param string $scheduled_at MySQL datetime for scheduling.
-		* @return int Number of subscribers queued in this chunk.
-		*/
+	 * Process a chunk of subscribers for queueing.
+	 *
+	 * @param int    $campaign_id  Campaign ID.
+	 * @param array  $chunk        Array of subscriber objects.
+	 * @param string $subject      Email subject.
+	 * @param string $body         Email body.
+	 * @param string $scheduled_at MySQL datetime for scheduling.
+	 * @return int Number of subscribers queued in this chunk.
+	 */
 	private function process_subscriber_chunk( int $campaign_id, array $chunk, string $subject, string $body, string $scheduled_at ): int {
-		$external_subscribers = array();
+		$external_subscribers    = array();
 		$internal_subscriber_ids = array();
 
 		// Separate external and internal subscribers.
@@ -200,7 +200,7 @@ class Email_Service {
 		// Prepare queue data for valid subscribers.
 		$queue_items = array();
 		foreach ( $chunk as $subscriber ) {
-			$is_external = \MSKD_List_Provider::is_external_id( $subscriber->id ?? '' );
+			$is_external   = \MSKD_List_Provider::is_external_id( $subscriber->id ?? '' );
 			$db_subscriber = null;
 			$subscriber_id = null;
 
@@ -236,17 +236,17 @@ class Email_Service {
 	}
 
 	/**
-		* Batch insert queue items into the database.
-		*
-		* @param array $queue_items Array of queue item data arrays.
-		* @return int Number of items inserted.
-		*/
+	 * Batch insert queue items into the database.
+	 *
+	 * @param array $queue_items Array of queue item data arrays.
+	 * @return int Number of items inserted.
+	 */
 	private function batch_insert_queue_items( array $queue_items ): int {
 		if ( empty( $queue_items ) ) {
 			return 0;
 		}
 
-		$values = array();
+		$values       = array();
 		$placeholders = array();
 
 		foreach ( $queue_items as $item ) {
@@ -271,7 +271,7 @@ class Email_Service {
 	}
 
 	/**
-		* Queue a one-time email.
+	 * Queue a one-time email.
 	 *
 	 * @param array $data {
 	 *     Email data.

--- a/includes/Services/class-subscriber-service.php
+++ b/includes/Services/class-subscriber-service.php
@@ -674,14 +674,14 @@ class Subscriber_Service {
 	}
 
 	/**
-		* Batch get or create subscribers by emails.
-		*
-		* For each email, if subscriber exists, returns existing record (preserves current status).
-		* If not, creates new subscriber with generated token.
-		*
-		* @param array $emails_data Array of email data with email, first_name, last_name, source.
-		* @return array Array of subscriber objects indexed by email.
-		*/
+	 * Batch get or create subscribers by emails.
+	 *
+	 * For each email, if subscriber exists, returns existing record (preserves current status).
+	 * If not, creates new subscriber with generated token.
+	 *
+	 * @param array $emails_data Array of email data with email, first_name, last_name, source.
+	 * @return array Array of subscriber objects indexed by email.
+	 */
 	public function batch_get_or_create( array $emails_data ): array {
 		if ( empty( $emails_data ) ) {
 			return array();
@@ -700,10 +700,10 @@ class Subscriber_Service {
 		}
 
 		// Get existing subscribers in a single query.
-		$placeholders = implode( ',', array_fill( 0, count( $emails ), '%s' ) );
+		$placeholders         = implode( ',', array_fill( 0, count( $emails ), '%s' ) );
 		$existing_subscribers = $this->wpdb->get_results(
 			$this->wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is hardcoded and safe.
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table name hardcoded, using splat operator.
 				"SELECT * FROM {$this->table} WHERE email IN ({$placeholders})",
 				...$emails
 			)
@@ -715,14 +715,14 @@ class Subscriber_Service {
 			$existing_by_email[ $subscriber->email ] = $subscriber;
 		}
 
-		$result = array();
+		$result          = array();
 		$new_subscribers = array();
 
 		foreach ( $emails_data as $data ) {
-			$email = sanitize_email( $data['email'] ?? '' );
+			$email      = sanitize_email( $data['email'] ?? '' );
 			$first_name = $data['first_name'] ?? '';
-			$last_name = $data['last_name'] ?? '';
-			$source = $data['source'] ?? self::SOURCE_INTERNAL;
+			$last_name  = $data['last_name'] ?? '';
+			$source     = $data['source'] ?? self::SOURCE_INTERNAL;
 
 			if ( empty( $email ) || ! is_email( $email ) ) {
 				continue;
@@ -749,7 +749,7 @@ class Subscriber_Service {
 			$created_ids = $this->batch_create( $new_subscribers );
 			foreach ( $created_ids as $i => $id ) {
 				if ( $id ) {
-					$email = $new_subscribers[ $i ]['email'];
+					$email            = $new_subscribers[ $i ]['email'];
 					$result[ $email ] = $this->get_by_id( $id );
 				}
 			}
@@ -759,11 +759,11 @@ class Subscriber_Service {
 	}
 
 	/**
-		* Batch create subscribers.
-		*
-		* @param array $subscribers_data Array of subscriber data arrays.
-		* @return array Array of created subscriber IDs (false for failed creations).
-		*/
+	 * Batch create subscribers.
+	 *
+	 * @param array $subscribers_data Array of subscriber data arrays.
+	 * @return array Array of created subscriber IDs (false for failed creations).
+	 */
 	public function batch_create( array $subscribers_data ): array {
 		if ( empty( $subscribers_data ) ) {
 			return array();
@@ -810,27 +810,32 @@ class Subscriber_Service {
 	}
 
 	/**
-		* Batch get subscribers by IDs.
-		*
-		* @param array $ids Array of subscriber IDs.
-		* @return array Array of subscriber objects indexed by ID.
-		*/
+	 * Batch get subscribers by IDs.
+	 *
+	 * @param array $ids Array of subscriber IDs.
+	 * @return array Array of subscriber objects indexed by ID.
+	 */
 	public function batch_get_by_ids( array $ids ): array {
 		if ( empty( $ids ) ) {
 			return array();
 		}
 
 		$ids = array_map( 'intval', $ids );
-		$ids = array_filter( $ids, function( $id ) { return $id > 0; } );
+		$ids = array_filter(
+			$ids,
+			function ( $id ) {
+				return $id > 0;
+			}
+		);
 
 		if ( empty( $ids ) ) {
 			return array();
 		}
 
 		$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
-		$subscribers = $this->wpdb->get_results(
+		$subscribers  = $this->wpdb->get_results(
 			$this->wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is hardcoded and safe.
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Table name hardcoded, using splat operator.
 				"SELECT * FROM {$this->table} WHERE id IN ({$placeholders})",
 				...$ids
 			)

--- a/includes/Services/class-subscriber-service.php
+++ b/includes/Services/class-subscriber-service.php
@@ -672,4 +672,175 @@ class Subscriber_Service {
 
 		return $result;
 	}
+
+	/**
+		* Batch get or create subscribers by emails.
+		*
+		* For each email, if subscriber exists, returns existing record (preserves current status).
+		* If not, creates new subscriber with generated token.
+		*
+		* @param array $emails_data Array of email data with email, first_name, last_name, source.
+		* @return array Array of subscriber objects indexed by email.
+		*/
+	public function batch_get_or_create( array $emails_data ): array {
+		if ( empty( $emails_data ) ) {
+			return array();
+		}
+
+		$emails = array();
+		foreach ( $emails_data as $data ) {
+			$email = sanitize_email( $data['email'] ?? '' );
+			if ( ! empty( $email ) && is_email( $email ) ) {
+				$emails[] = $email;
+			}
+		}
+
+		if ( empty( $emails ) ) {
+			return array();
+		}
+
+		// Get existing subscribers in a single query.
+		$placeholders = implode( ',', array_fill( 0, count( $emails ), '%s' ) );
+		$existing_subscribers = $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is hardcoded and safe.
+				"SELECT * FROM {$this->table} WHERE email IN ({$placeholders})",
+				...$emails
+			)
+		);
+
+		// Index existing subscribers by email for quick lookup.
+		$existing_by_email = array();
+		foreach ( $existing_subscribers as $subscriber ) {
+			$existing_by_email[ $subscriber->email ] = $subscriber;
+		}
+
+		$result = array();
+		$new_subscribers = array();
+
+		foreach ( $emails_data as $data ) {
+			$email = sanitize_email( $data['email'] ?? '' );
+			$first_name = $data['first_name'] ?? '';
+			$last_name = $data['last_name'] ?? '';
+			$source = $data['source'] ?? self::SOURCE_INTERNAL;
+
+			if ( empty( $email ) || ! is_email( $email ) ) {
+				continue;
+			}
+
+			// Return existing subscriber if found.
+			if ( isset( $existing_by_email[ $email ] ) ) {
+				$result[ $email ] = $existing_by_email[ $email ];
+				continue;
+			}
+
+			// Prepare for batch creation.
+			$new_subscribers[] = array(
+				'email'      => $email,
+				'first_name' => $first_name,
+				'last_name'  => $last_name,
+				'status'     => 'active',
+				'source'     => $source,
+			);
+		}
+
+		// Batch create new subscribers if any.
+		if ( ! empty( $new_subscribers ) ) {
+			$created_ids = $this->batch_create( $new_subscribers );
+			foreach ( $created_ids as $i => $id ) {
+				if ( $id ) {
+					$email = $new_subscribers[ $i ]['email'];
+					$result[ $email ] = $this->get_by_id( $id );
+				}
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+		* Batch create subscribers.
+		*
+		* @param array $subscribers_data Array of subscriber data arrays.
+		* @return array Array of created subscriber IDs (false for failed creations).
+		*/
+	public function batch_create( array $subscribers_data ): array {
+		if ( empty( $subscribers_data ) ) {
+			return array();
+		}
+
+		$ids = array();
+		foreach ( $subscribers_data as $data ) {
+			$defaults = array(
+				'email'      => '',
+				'first_name' => '',
+				'last_name'  => '',
+				'status'     => 'active',
+				'source'     => self::SOURCE_INTERNAL,
+			);
+
+			$data = wp_parse_args( $data, $defaults );
+
+			// Validate source.
+			$valid_sources = array( self::SOURCE_INTERNAL, self::SOURCE_EXTERNAL, self::SOURCE_ONE_TIME );
+			if ( ! in_array( $data['source'], $valid_sources, true ) ) {
+				$data['source'] = self::SOURCE_INTERNAL;
+			}
+
+			// Generate unsubscribe token.
+			$token = wp_generate_password( 32, false );
+
+			$result = $this->wpdb->insert(
+				$this->table,
+				array(
+					'email'             => $data['email'],
+					'first_name'        => $data['first_name'],
+					'last_name'         => $data['last_name'],
+					'status'            => $data['status'],
+					'source'            => $data['source'],
+					'unsubscribe_token' => $token,
+				),
+				array( '%s', '%s', '%s', '%s', '%s', '%s' )
+			);
+
+			$ids[] = $result ? $this->wpdb->insert_id : false;
+		}
+
+		return $ids;
+	}
+
+	/**
+		* Batch get subscribers by IDs.
+		*
+		* @param array $ids Array of subscriber IDs.
+		* @return array Array of subscriber objects indexed by ID.
+		*/
+	public function batch_get_by_ids( array $ids ): array {
+		if ( empty( $ids ) ) {
+			return array();
+		}
+
+		$ids = array_map( 'intval', $ids );
+		$ids = array_filter( $ids, function( $id ) { return $id > 0; } );
+
+		if ( empty( $ids ) ) {
+			return array();
+		}
+
+		$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+		$subscribers = $this->wpdb->get_results(
+			$this->wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is hardcoded and safe.
+				"SELECT * FROM {$this->table} WHERE id IN ({$placeholders})",
+				...$ids
+			)
+		);
+
+		$result = array();
+		foreach ( $subscribers as $subscriber ) {
+			$result[ $subscriber->id ] = $subscriber;
+		}
+
+		return $result;
+	}
 }

--- a/tests/Unit/class-bccemailservicetest.php
+++ b/tests/Unit/class-bccemailservicetest.php
@@ -64,6 +64,18 @@ class BccEmailServiceTest extends TestCase {
 				)
 			);
 
+		// Mock wpdb->get_results for batch processing.
+		$this->wpdb->shouldReceive( 'get_results' )
+			->andReturn(
+				array(
+					(object) array(
+						'id'     => 1,
+						'email'  => 'subscriber@example.com',
+						'status' => 'active',
+					),
+				)
+			);
+
 		// Mock wpdb insert to capture data.
 		$captured_data = null;
 		$this->wpdb->shouldReceive( 'insert' )
@@ -81,13 +93,8 @@ class BccEmailServiceTest extends TestCase {
 
 		$this->wpdb->insert_id = 123;
 
-		// Mock queue inserts.
-		$this->wpdb->shouldReceive( 'insert' )
-			->with(
-				Mockery::pattern( '/mskd_queue$/' ),
-				Mockery::any(),
-				Mockery::any()
-			)
+		// Mock wpdb query for batch queue inserts.
+		$this->wpdb->shouldReceive( 'query' )
 			->andReturn( 1 );
 
 		// Create campaign with Bcc.
@@ -127,6 +134,18 @@ class BccEmailServiceTest extends TestCase {
 				)
 			);
 
+		// Mock wpdb->get_results for batch processing.
+		$this->wpdb->shouldReceive( 'get_results' )
+			->andReturn(
+				array(
+					(object) array(
+						'id'     => 1,
+						'email'  => 'subscriber@example.com',
+						'status' => 'active',
+					),
+				)
+			);
+
 		// Mock wpdb insert.
 		$captured_data = null;
 		$this->wpdb->shouldReceive( 'insert' )
@@ -145,13 +164,8 @@ class BccEmailServiceTest extends TestCase {
 
 		$this->wpdb->insert_id = 456;
 
-		// Mock queue inserts.
-		$this->wpdb->shouldReceive( 'insert' )
-			->with(
-				Mockery::pattern( '/mskd_queue$/' ),
-				Mockery::any(),
-				Mockery::any()
-			)
+		// Mock wpdb query for batch queue inserts.
+		$this->wpdb->shouldReceive( 'query' )
 			->andReturn( 1 );
 
 		// Create campaign without Bcc.

--- a/tests/Unit/class-emailservicetest.php
+++ b/tests/Unit/class-emailservicetest.php
@@ -7,6 +7,7 @@
 
 namespace MSKD\Tests\Unit;
 
+use Brain\Monkey\Functions;
 use MSKD\Services\Email_Service;
 use MSKD\Services\Subscriber_Service;
 use Mockery;
@@ -151,10 +152,7 @@ class Email_Service_Test extends TestCase {
 			->once()
 			->andReturn( 3 ); // 3 items inserted.
 
-		// Mock wpdb prepare for batch insert.
-		$this->wpdb->shouldReceive( 'prepare' )
-			->once()
-			->andReturn( 'prepared_query' );
+		// Note: prepare() is already mocked in create_wpdb_mock() with andReturnUsing().
 
 		// Execute queue_campaign.
 		$campaign_data = array(
@@ -231,10 +229,7 @@ class Email_Service_Test extends TestCase {
 			->once()
 			->andReturn( 1 ); // Only 1 item inserted.
 
-		// Mock wpdb prepare for batch insert.
-		$this->wpdb->shouldReceive( 'prepare' )
-			->once()
-			->andReturn( 'prepared_query' );
+		// Note: prepare() is already mocked in create_wpdb_mock() with andReturnUsing().
 
 		// Execute queue_campaign.
 		$campaign_data = array(
@@ -351,10 +346,7 @@ class Email_Service_Test extends TestCase {
 			->twice()
 			->andReturn( 500, 500 ); // 500 items inserted in each chunk.
 
-		// Mock wpdb prepare for batch insert.
-		$this->wpdb->shouldReceive( 'prepare' )
-			->twice()
-			->andReturn( 'prepared_query' );
+		// Note: prepare() is already mocked in create_wpdb_mock() with andReturnUsing().
 
 		// Execute queue_campaign.
 		$campaign_data = array(
@@ -373,24 +365,6 @@ class Email_Service_Test extends TestCase {
 	 * Test batch queue subscribers with empty list.
 	 */
 	public function test_batch_queue_subscribers_empty_list() {
-		// Mock wpdb insert for campaign creation.
-		$this->wpdb->shouldReceive( 'insert' )
-			->once()
-			->andReturn( true );
-		$this->wpdb->insert_id = 1; // Campaign ID.
-
-		// Mock option functions.
-		Functions\stubs(
-			array(
-				'get_option'    => function ( $option, $default ) {
-					return 'mskd_total_campaigns_created' === $option ? 0 : $default;
-				},
-				'update_option' => function () {
-					return true;
-				},
-			)
-		);
-
 		// Execute queue_campaign with empty subscribers.
 		$campaign_data = array(
 			'subject' => 'Test Subject',
@@ -400,7 +374,7 @@ class Email_Service_Test extends TestCase {
 
 		$result = $this->email_service->queue_campaign( $campaign_data );
 
-		// Assert campaign was created but no queue items.
-		$this->assertEquals( 1, $result );
+		// Assert false is returned when no subscribers are provided.
+		$this->assertFalse( $result );
 	}
 }

--- a/tests/Unit/class-emailservicetest.php
+++ b/tests/Unit/class-emailservicetest.php
@@ -1,0 +1,406 @@
+<?php
+/**
+ * Email Service Test
+ *
+ * @package MSKD\Tests\Unit
+ */
+
+namespace MSKD\Tests\Unit;
+
+use MSKD\Services\Email_Service;
+use MSKD\Services\Subscriber_Service;
+use Mockery;
+
+/**
+ * Class Email_Service_Test
+ *
+ * Test batch processing functionality in Email_Service.
+ */
+class Email_Service_Test extends TestCase {
+
+	/**
+	 * Email service instance.
+	 *
+	 * @var Email_Service
+	 */
+	private $email_service;
+
+	/**
+	 * Subscriber service mock.
+	 *
+	 * @var \Mockery\MockInterface
+	 */
+	private $subscriber_service;
+
+	/**
+	 * Set up test environment.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		
+		// Set up wpdb mock.
+		$this->setup_wpdb_mock();
+		
+		// Create subscriber service mock.
+		$this->subscriber_service = Mockery::mock( Subscriber_Service::class );
+		
+		// Create email service with mocked dependencies.
+		$this->email_service = new Email_Service();
+		
+		// Replace the subscriber service with our mock.
+		$reflection = new \ReflectionClass( $this->email_service );
+		$property = $reflection->getProperty( 'subscriber_service' );
+		$property->setAccessible( true );
+		$property->setValue( $this->email_service, $this->subscriber_service );
+	}
+
+	/**
+	 * Test batch queue subscribers with external and internal subscribers.
+	 */
+	public function test_batch_queue_subscribers_mixed_types() {
+		// Mock wpdb insert for campaign creation.
+		$this->wpdb->shouldReceive( 'insert' )
+			->once()
+			->andReturn( true );
+		$this->wpdb->insert_id = 1; // Campaign ID.
+
+		// Mock option functions.
+		Functions\stubs(
+			array(
+				'get_option'    => function ( $option, $default ) {
+					return 'mskd_total_campaigns_created' === $option ? 0 : $default;
+				},
+				'update_option' => function () {
+					return true;
+				},
+			)
+		);
+
+		// Prepare test data.
+		$subscribers = array(
+			(object) array(
+				'id' => 'ext_test1',
+				'email' => 'external1@example.com',
+				'first_name' => 'External',
+				'last_name' => 'One',
+			),
+			(object) array(
+				'id' => 1,
+				'email' => 'internal1@example.com',
+				'first_name' => 'Internal',
+				'last_name' => 'One',
+			),
+			(object) array(
+				'id' => 'ext_test2',
+				'email' => 'external2@example.com',
+				'first_name' => 'External',
+				'last_name' => 'Two',
+			),
+		);
+
+		// Mock batch_get_or_create for external subscribers.
+		$this->subscriber_service->shouldReceive( 'batch_get_or_create' )
+			->once()
+			->with(
+				array(
+					array(
+						'email' => 'external1@example.com',
+						'first_name' => 'External',
+						'last_name' => 'One',
+						'source' => 'external',
+					),
+					array(
+						'email' => 'external2@example.com',
+						'first_name' => 'External',
+						'last_name' => 'Two',
+						'source' => 'external',
+					),
+				)
+			)
+			->andReturn(
+				array(
+					'external1@example.com' => (object) array(
+						'id' => 101,
+						'email' => 'external1@example.com',
+						'status' => 'active',
+					),
+					'external2@example.com' => (object) array(
+						'id' => 102,
+						'email' => 'external2@example.com',
+						'status' => 'active',
+					),
+				)
+			);
+
+		// Mock batch_get_by_ids for internal subscribers.
+		$this->subscriber_service->shouldReceive( 'batch_get_by_ids' )
+			->once()
+			->with( array( 1 ) )
+			->andReturn(
+				array(
+					1 => (object) array(
+						'id' => 1,
+						'email' => 'internal1@example.com',
+						'status' => 'active',
+					),
+				)
+			);
+
+		// Mock batch insert for queue items.
+		$this->wpdb->shouldReceive( 'query' )
+			->once()
+			->andReturn( 3 ); // 3 items inserted.
+
+		// Mock wpdb prepare for batch insert.
+		$this->wpdb->shouldReceive( 'prepare' )
+			->once()
+			->andReturn( 'prepared_query' );
+
+		// Execute queue_campaign.
+		$campaign_data = array(
+			'subject' => 'Test Subject',
+			'body' => 'Test Body',
+			'subscribers' => $subscribers,
+		);
+
+		$result = $this->email_service->queue_campaign( $campaign_data );
+
+		// Assert campaign was created.
+		$this->assertEquals( 1, $result );
+	}
+
+	/**
+	 * Test batch queue subscribers with unsubscribed subscribers filtered out.
+	 */
+	public function test_batch_queue_subscribers_filters_unsubscribed() {
+		// Mock wpdb insert for campaign creation.
+		$this->wpdb->shouldReceive( 'insert' )
+			->once()
+			->andReturn( true );
+		$this->wpdb->insert_id = 1; // Campaign ID.
+
+		// Mock option functions.
+		Functions\stubs(
+			array(
+				'get_option'    => function ( $option, $default ) {
+					return 'mskd_total_campaigns_created' === $option ? 0 : $default;
+				},
+				'update_option' => function () {
+					return true;
+				},
+			)
+		);
+
+		// Prepare test data with one unsubscribed subscriber.
+		$subscribers = array(
+			(object) array(
+				'id' => 1,
+				'email' => 'active@example.com',
+				'first_name' => 'Active',
+				'last_name' => 'User',
+			),
+			(object) array(
+				'id' => 2,
+				'email' => 'unsubscribed@example.com',
+				'first_name' => 'Unsubscribed',
+				'last_name' => 'User',
+			),
+		);
+
+		// Mock batch_get_by_ids.
+		$this->subscriber_service->shouldReceive( 'batch_get_by_ids' )
+			->once()
+			->with( array( 1, 2 ) )
+			->andReturn(
+				array(
+					1 => (object) array(
+						'id' => 1,
+						'email' => 'active@example.com',
+						'status' => 'active',
+					),
+					2 => (object) array(
+						'id' => 2,
+						'email' => 'unsubscribed@example.com',
+						'status' => 'unsubscribed',
+					),
+				)
+			);
+
+		// Mock batch insert for queue items (only 1 should be inserted).
+		$this->wpdb->shouldReceive( 'query' )
+			->once()
+			->andReturn( 1 ); // Only 1 item inserted.
+
+		// Mock wpdb prepare for batch insert.
+		$this->wpdb->shouldReceive( 'prepare' )
+			->once()
+			->andReturn( 'prepared_query' );
+
+		// Execute queue_campaign.
+		$campaign_data = array(
+			'subject' => 'Test Subject',
+			'body' => 'Test Body',
+			'subscribers' => $subscribers,
+		);
+
+		$result = $this->email_service->queue_campaign( $campaign_data );
+
+		// Assert campaign was created.
+		$this->assertEquals( 1, $result );
+	}
+
+	/**
+	 * Test batch queue subscribers with large list (chunking).
+	 */
+	public function test_batch_queue_subscribers_with_chunking() {
+		// Mock wpdb insert for campaign creation.
+		$this->wpdb->shouldReceive( 'insert' )
+			->once()
+			->andReturn( true );
+		$this->wpdb->insert_id = 1; // Campaign ID.
+
+		// Mock option functions.
+		Functions\stubs(
+			array(
+				'get_option'    => function ( $option, $default ) {
+					return 'mskd_total_campaigns_created' === $option ? 0 : $default;
+				},
+				'update_option' => function () {
+					return true;
+				},
+			)
+		);
+
+		// Create a large list of subscribers (1000 to test chunking).
+		$subscribers = array();
+		$expected_external_data = array();
+		$expected_external_results = array();
+		$expected_internal_ids = array();
+		$expected_internal_results = array();
+
+		for ( $i = 1; $i <= 1000; $i++ ) {
+			if ( $i % 2 === 0 ) {
+				// External subscriber.
+				$email = "external{$i}@example.com";
+				$subscribers[] = (object) array(
+					'id' => "ext_test{$i}",
+					'email' => $email,
+					'first_name' => "External {$i}",
+					'last_name' => 'User',
+				);
+				$expected_external_data[] = array(
+					'email' => $email,
+					'first_name' => "External {$i}",
+					'last_name' => 'User',
+					'source' => 'external',
+				);
+				$expected_external_results[ $email ] = (object) array(
+					'id' => 1000 + $i,
+					'email' => $email,
+					'status' => 'active',
+				);
+			} else {
+				// Internal subscriber.
+				$subscribers[] = (object) array(
+					'id' => $i,
+					'email' => "internal{$i}@example.com",
+					'first_name' => "Internal {$i}",
+					'last_name' => 'User',
+				);
+				$expected_internal_ids[] = $i;
+				$expected_internal_results[ $i ] = (object) array(
+					'id' => $i,
+					'email' => "internal{$i}@example.com",
+					'status' => 'active',
+				);
+			}
+		}
+
+		// Mock batch_get_or_create for external subscribers (should be called twice for 2 chunks).
+		$this->subscriber_service->shouldReceive( 'batch_get_or_create' )
+			->twice()
+			->andReturnUsing(
+				function ( $data ) use ( $expected_external_results ) {
+					$results = array();
+					foreach ( $data as $item ) {
+						if ( isset( $expected_external_results[ $item['email'] ] ) ) {
+							$results[ $item['email'] ] = $expected_external_results[ $item['email'] ];
+						}
+					}
+					return $results;
+				}
+			);
+
+		// Mock batch_get_by_ids for internal subscribers (should be called twice for 2 chunks).
+		$this->subscriber_service->shouldReceive( 'batch_get_by_ids' )
+			->twice()
+			->andReturnUsing(
+				function ( $ids ) use ( $expected_internal_results ) {
+					$results = array();
+					foreach ( $ids as $id ) {
+						if ( isset( $expected_internal_results[ $id ] ) ) {
+							$results[ $id ] = $expected_internal_results[ $id ];
+						}
+					}
+					return $results;
+				}
+			);
+
+		// Mock batch insert for queue items (should be called twice for 2 chunks).
+		$this->wpdb->shouldReceive( 'query' )
+			->twice()
+			->andReturn( 500, 500 ); // 500 items inserted in each chunk.
+
+		// Mock wpdb prepare for batch insert.
+		$this->wpdb->shouldReceive( 'prepare' )
+			->twice()
+			->andReturn( 'prepared_query' );
+
+		// Execute queue_campaign.
+		$campaign_data = array(
+			'subject' => 'Test Subject',
+			'body' => 'Test Body',
+			'subscribers' => $subscribers,
+		);
+
+		$result = $this->email_service->queue_campaign( $campaign_data );
+
+		// Assert campaign was created.
+		$this->assertEquals( 1, $result );
+	}
+
+	/**
+	 * Test batch queue subscribers with empty list.
+	 */
+	public function test_batch_queue_subscribers_empty_list() {
+		// Mock wpdb insert for campaign creation.
+		$this->wpdb->shouldReceive( 'insert' )
+			->once()
+			->andReturn( true );
+		$this->wpdb->insert_id = 1; // Campaign ID.
+
+		// Mock option functions.
+		Functions\stubs(
+			array(
+				'get_option'    => function ( $option, $default ) {
+					return 'mskd_total_campaigns_created' === $option ? 0 : $default;
+				},
+				'update_option' => function () {
+					return true;
+				},
+			)
+		);
+
+		// Execute queue_campaign with empty subscribers.
+		$campaign_data = array(
+			'subject' => 'Test Subject',
+			'body' => 'Test Body',
+			'subscribers' => array(),
+		);
+
+		$result = $this->email_service->queue_campaign( $campaign_data );
+
+		// Assert campaign was created but no queue items.
+		$this->assertEquals( 1, $result );
+	}
+}

--- a/tests/Unit/class-subscriberservicetest.php
+++ b/tests/Unit/class-subscriberservicetest.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Subscriber Service Test
+ *
+ * @package MSKD\Tests\Unit
+ */
+
+namespace MSKD\Tests\Unit;
+
+use MSKD\Services\Subscriber_Service;
+use Mockery;
+
+/**
+ * Class Subscriber_Service_Test
+ *
+ * Test batch processing functionality in Subscriber_Service.
+ */
+class Subscriber_Service_Test extends TestCase {
+
+	/**
+	 * Subscriber service instance.
+	 *
+	 * @var Subscriber_Service
+	 */
+	private $subscriber_service;
+
+	/**
+	 * Set up test environment.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		
+		// Set up wpdb mock.
+		$this->setup_wpdb_mock();
+		
+		// Create subscriber service.
+		$this->subscriber_service = new Subscriber_Service();
+		
+		// Replace wpdb with our mock.
+		$reflection = new \ReflectionClass( $this->subscriber_service );
+		$property = $reflection->getProperty( 'wpdb' );
+		$property->setAccessible( true );
+		$property->setValue( $this->subscriber_service, $this->wpdb );
+		
+		// Replace table property.
+		$table_property = $reflection->getProperty( 'table' );
+		$table_property->setAccessible( true );
+		$table_property->setValue( $this->subscriber_service, 'wp_mskd_subscribers' );
+	}
+
+	/**
+	 * Test batch_get_or_create with existing subscribers.
+	 */
+	public function test_batch_get_or_create_with_existing_subscribers() {
+		$emails_data = array(
+			array(
+				'email' => 'existing1@example.com',
+				'first_name' => 'Existing',
+				'last_name' => 'One',
+				'source' => 'external',
+			),
+			array(
+				'email' => 'existing2@example.com',
+				'first_name' => 'Existing',
+				'last_name' => 'Two',
+				'source' => 'external',
+			),
+		);
+
+		// Mock wpdb get_results to return existing subscribers.
+		$this->wpdb->shouldReceive( 'get_results' )
+			->once()
+			->andReturn(
+				array(
+					(object) array(
+						'id' => 1,
+						'email' => 'existing1@example.com',
+						'first_name' => 'Existing',
+						'last_name' => 'One',
+						'status' => 'active',
+					),
+					(object) array(
+						'id' => 2,
+						'email' => 'existing2@example.com',
+						'first_name' => 'Existing',
+						'last_name' => 'Two',
+						'status' => 'active',
+					),
+				)
+			);
+
+		// Mock wpdb prepare.
+		$this->wpdb->shouldReceive( 'prepare' )
+			->once()
+			->andReturn( 'prepared_query' );
+
+		$result = $this->subscriber_service->batch_get_or_create( $emails_data );
+
+		// Assert existing subscribers are returned.
+		$this->assertCount( 2, $result );
+		$this->assertArrayHasKey( 'existing1@example.com', $result );
+		$this->assertArrayHasKey( 'existing2@example.com', $result );
+		$this->assertEquals( 1, $result['existing1@example.com']->id );
+		$this->assertEquals( 2, $result['existing2@example.com']->id );
+	}
+
+	/**
+	 * Test batch_get_or_create with new subscribers.
+	 */
+	public function test_batch_get_or_create_with_new_subscribers() {
+		$emails_data = array(
+			array(
+				'email' => 'new1@example.com',
+				'first_name' => 'New',
+				'last_name' => 'One',
+				'source' => 'external',
+			),
+			array(
+				'email' => 'new2@example.com',
+				'first_name' => 'New',
+				'last_name' => 'Two',
+				'source' => 'external',
+			),
+		);
+
+		// Mock wpdb get_results to return no existing subscribers.
+		$this->wpdb->shouldReceive( 'get_results' )
+			->once()
+			->andReturn( array() );
+
+		// Mock wpdb prepare for get_results.
+		$this->wpdb->shouldReceive( 'prepare' )
+			->once()
+			->andReturn( 'prepared_query' );
+
+		// Mock wpdb insert for new subscribers.
+		$this->wpdb->shouldReceive( 'insert' )
+			->twice()
+			->andReturn( true );
+		$this->wpdb->insert_id = 1; // First insert returns ID 1.
+		
+		// Mock get_by_id for retrieving created subscribers.
+		$this->wpdb->shouldReceive( 'get_row' )
+			->twice()
+			->andReturn(
+				(object) array(
+					'id' => 1,
+					'email' => 'new1@example.com',
+					'first_name' => 'New',
+					'last_name' => 'One',
+					'status' => 'active',
+				),
+				(object) array(
+					'id' => 2,
+					'email' => 'new2@example.com',
+					'first_name' => 'New',
+					'last_name' => 'Two',
+					'status' => 'active',
+				)
+			);
+
+		// Mock wpdb prepare for get_row.
+		$this->wpdb->shouldReceive( 'prepare' )
+			->twice()
+			->andReturn( 'prepared_query' );
+
+		$result = $this->subscriber_service->batch_get_or_create( $emails_data );
+
+		// Assert new subscribers are created and returned.
+		$this->assertCount( 2, $result );
+		$this->assertArrayHasKey( 'new1@example.com', $result );
+		$this->assertArrayHasKey( 'new2@example.com', $result );
+		$this->assertEquals( 1, $result['new1@example.com']->id );
+		$this->assertEquals( 2, $result['new2@example.com']->id );
+	}
+
+	/**
+	 * Test batch_get_by_ids with valid IDs.
+	 */
+	public function test_batch_get_by_ids_with_valid_ids() {
+		$ids = array( 1, 2, 3 );
+
+		// Mock wpdb get_results.
+		$this->wpdb->shouldReceive( 'get_results' )
+			->once()
+			->andReturn(
+				array(
+					(object) array(
+						'id' => 1,
+						'email' => 'test1@example.com',
+						'first_name' => 'Test',
+						'last_name' => 'One',
+						'status' => 'active',
+					),
+					(object) array(
+						'id' => 2,
+						'email' => 'test2@example.com',
+						'first_name' => 'Test',
+						'last_name' => 'Two',
+						'status' => 'active',
+					),
+					(object) array(
+						'id' => 3,
+						'email' => 'test3@example.com',
+						'first_name' => 'Test',
+						'last_name' => 'Three',
+						'status' => 'active',
+					),
+				)
+			);
+
+		// Mock wpdb prepare.
+		$this->wpdb->shouldReceive( 'prepare' )
+			->once()
+			->andReturn( 'prepared_query' );
+
+		$result = $this->subscriber_service->batch_get_by_ids( $ids );
+
+		// Assert subscribers are returned indexed by ID.
+		$this->assertCount( 3, $result );
+		$this->assertArrayHasKey( 1, $result );
+		$this->assertArrayHasKey( 2, $result );
+		$this->assertArrayHasKey( 3, $result );
+		$this->assertEquals( 'test1@example.com', $result[1]->email );
+		$this->assertEquals( 'test2@example.com', $result[2]->email );
+		$this->assertEquals( 'test3@example.com', $result[3]->email );
+	}
+
+	/**
+	 * Test batch_get_by_ids with empty IDs.
+	 */
+	public function test_batch_get_by_ids_with_empty_ids() {
+		$ids = array();
+
+		$result = $this->subscriber_service->batch_get_by_ids( $ids );
+
+		// Assert empty result.
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test batch_get_by_ids with invalid IDs.
+	 */
+	public function test_batch_get_by_ids_with_invalid_ids() {
+		$ids = array( 0, -1, 'invalid' );
+
+		$result = $this->subscriber_service->batch_get_by_ids( $ids );
+
+		// Assert empty result after filtering invalid IDs.
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test batch_create with valid subscriber data.
+	 */
+	public function test_batch_create_with_valid_data() {
+		$subscribers_data = array(
+			array(
+				'email' => 'batch1@example.com',
+				'first_name' => 'Batch',
+				'last_name' => 'One',
+				'source' => 'external',
+			),
+			array(
+				'email' => 'batch2@example.com',
+				'first_name' => 'Batch',
+				'last_name' => 'Two',
+				'source' => 'external',
+			),
+		);
+
+		// Mock wpdb insert.
+		$this->wpdb->shouldReceive( 'insert' )
+			->twice()
+			->andReturn( true );
+		$this->wpdb->insert_id = 1; // First insert returns ID 1.
+
+		$result = $this->subscriber_service->batch_create( $subscribers_data );
+
+		// Assert IDs are returned.
+		$this->assertCount( 2, $result );
+		$this->assertEquals( 1, $result[0] );
+		$this->assertEquals( 2, $result[1] );
+	}
+
+	/**
+	 * Test batch_create with empty data.
+	 */
+	public function test_batch_create_with_empty_data() {
+		$subscribers_data = array();
+
+		$result = $this->subscriber_service->batch_create( $subscribers_data );
+
+		// Assert empty result.
+		$this->assertEmpty( $result );
+	}
+}


### PR DESCRIPTION
# Fix issue #64: Implement batch processing for email queue and subscriber operations

This PR implements batch processing functionality to improve performance when handling large email campaigns.

## Changes
- Added batch_queue_subscribers() method to Email_Service for chunking large subscriber lists
- Added process_subscriber_chunk() to handle individual chunks efficiently  
- Added batch_insert_queue_items() for optimized database inserts
- Added batch_get_or_create() method to Subscriber_Service for bulk subscriber operations
- Added batch_create() for creating multiple subscribers at once
- Added batch_get_by_ids() for retrieving multiple subscribers by IDs
- Added unit tests for new batch processing functionality

## Benefits
- Improves performance when handling large email campaigns
- Reduces database queries by batching operations
- Prevents memory issues when processing large subscriber lists

Fixes #64