### PR TITLE
fix: scope list validation to step 3 in compose wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Compose Wizard Step 1 Validation**
+  - Fixed bug where "Please select at least one list" alert incorrectly appeared when clicking Continue in step 1
+  - List validation now only triggers in step 3 where list selection is available
+
 ## [1.1.1] - 2025-12-19
 
 ### Added

--- a/admin/partials/compose-wizard.php
+++ b/admin/partials/compose-wizard.php
@@ -1146,12 +1146,15 @@ jQuery(document).ready(function($) {
 
 	// Form validation
 	$('form').on('submit', function(e) {
-		// Validate recipients
-		var lists = $('#mskd-lists-select').val();
-		if (!lists || lists.length === 0) {
-			e.preventDefault();
-			alert('<?php echo esc_js( __( 'Please select at least one list.', 'mail-system-by-katsarov-design' ) ); ?>');
-			return false;
+		// Only validate recipients on step 3 (where the list select exists)
+		var $listsSelect = $('#mskd-lists-select');
+		if ($listsSelect.length > 0) {
+			var lists = $listsSelect.val();
+			if (!lists || lists.length === 0) {
+				e.preventDefault();
+				alert('<?php echo esc_js( __( 'Please select at least one list.', 'mail-system-by-katsarov-design' ) ); ?>');
+				return false;
+			}
 		}
 
 		var useCustom = $('input[name="use_custom_from"]:checked').val();


### PR DESCRIPTION
## Problem
When clicking **Continue** in step 1 of the compose wizard, users see the alert "Please select at least one list" - even though list selection only exists in step 3.

## Root Cause
The JavaScript validation used a generic `$('form').on('submit')` which triggered on ALL forms. Since `#mskd-lists-select` doesn't exist in step 1, `$('#mskd-lists-select').val()` returns `null`, incorrectly triggering the validation.

## Fix
Added a check for the list selector's existence before validating:
```javascript
var $listsSelect = $('#mskd-lists-select');
if ($listsSelect.length > 0) {
    // validate only when element exists
}
```

## Testing
- [x] Step 1: Click Continue → navigates to step 2 (no alert)
- [x] Step 3: Click Send without list → shows validation alert