### PR TITLE
fix: sync bulk actions Apply button visibility on page load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Bulk actions Apply button not showing** — on the Subscribers page, if a browser restored the bulk actions dropdown's previous value on page load/refresh without firing a `change` event, the Apply button stayed hidden even though a bulk action was selected and subscribers were checked. The button's visibility is now synced on page load, not only on `change`.
 - **Opt-in confirmation email wrappers** — confirmation emails now apply the configured email header and footer and replace wrapper template variables (`{first_name}`, `{last_name}`, `{email}`, `{unsubscribe_link}`, `{unsubscribe_url}`) before sending.
 - **SMTP password encryption delimiter handling** — encrypted payloads now encode the IV separately before adding the delimiter and still support legacy raw-IV payloads, preventing rare decrypt failures when random IV bytes contained the delimiter sequence.
 - **Database repair notice persisting infinitely** — when clicking "Repair Database Now", if the required database table or column did not exist (or `ALTER TABLE` silently failed), the repair notice was shown on every page load indefinitely. The handler now calls `MSKD_Activator::activate()` (which uses `dbDelta` to create missing tables and columns), verifies the schema afterwards, and — if still failing — shows an actionable error notice with the database error message. The schema check also now correctly detects a missing table (not just a missing column).

--- a/admin/js/admin-script.js
+++ b/admin/js/admin-script.js
@@ -637,8 +637,8 @@
             }
 
             // Toggle bulk action controls based on selected action
-            $('#mskd-bulk-action').on('change', function() {
-                var action = $(this).val();
+            function syncBulkActionControls() {
+                var action = $('#mskd-bulk-action').val();
                 if (action === 'assign_lists' || action === 'remove_lists') {
                     $('#mskd-bulk-list-wrapper').show();
                     $('#mskd-bulk-apply').show();
@@ -651,7 +651,13 @@
                     $('#mskd-bulk-list-wrapper').hide();
                     $('#mskd-bulk-apply').hide();
                 }
-            });
+            }
+
+            $('#mskd-bulk-action').on('change', syncBulkActionControls);
+
+            // Some browsers restore the select's previous value on page load/refresh
+            // without firing a change event, leaving the Apply button hidden. Sync once on init.
+            syncBulkActionControls();
 
             // Select all checkboxes
             $('#mskd-select-all').on('change', function() {


### PR DESCRIPTION
## Summary
Follow-up to #102. After merging, testing surfaced a case where the bulk actions bar shows a selected action (e.g. "Set active") and a non-zero selected count, but the **Apply** button stays hidden.

## Root cause
The Apply button's visibility was only toggled inside the `#mskd-bulk-action` `change` handler. Some browsers restore a `<select>`'s previous value on refresh/back-forward navigation without dispatching a `change` event, so the dropdown can end up showing a selected bulk action (with subscribers checked) while the Apply button's `display: none` is never cleared.

## Fix
`admin/js/admin-script.js`: extracted the toggle logic into `syncBulkActionControls()` and run it once on page init (in addition to on `change`), so the Apply button's visibility always matches the select's actual current value regardless of how it got there.

## Test plan
- [x] `php vendor/bin/phpunit --configuration tests/phpunit.xml --testsuite Unit` — 198 tests pass (no PHP touched by this change)
- [x] `node -c admin/js/admin-script.js` — syntax valid