### PR TITLE
Fix wizard button arrow alignment

### DIFF
--- a/admin/partials/compose-wizard.php
+++ b/admin/partials/compose-wizard.php
@@ -849,6 +849,9 @@ $min_datetime = $now->format( 'Y-m-d\TH:i' );
 }
 
 .mskd-wizard-actions .button .dashicons {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 	font-size: 16px;
 	width: 16px;
 	height: 16px;
@@ -861,7 +864,10 @@ $min_datetime = $now->format( 'Y-m-d\TH:i' );
 	gap: 8px;
 }
 
-.mskd-wizard-actions .button-hero .dashicons {
+.mskd-wizard-actions .button.button-hero .dashicons {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 	font-size: 18px;
 	width: 18px;
 	height: 18px;
@@ -883,7 +889,10 @@ $min_datetime = $now->format( 'Y-m-d\TH:i' );
 	gap: 8px;
 }
 
-.mskd-visual-editor-launch .button-hero .dashicons {
+.mskd-visual-editor-launch .button.button-hero .dashicons {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 	font-size: 18px;
 	width: 18px;
 	height: 18px;


### PR DESCRIPTION
## Summary

- Center Dashicons inside compose wizard action buttons so the Continue arrow aligns with the label.
- Use selectors that override WordPress admin hero-button Dashicons line-height rules.

## Validation

- `php -l admin/partials/compose-wizard.php`
- `git diff --check`
- `php vendor/bin/phpcs admin/partials/compose-wizard.php`

## Notes

Root cause: WordPress admin applies a more specific `.button.button-hero .dashicons` line-height rule, which can leave the wizard arrow visually offset inside hero buttons.