### PR TITLE
Release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+### Security
+
+## [1.1.2] - 2026-07-17
+
+### Added
 - **Local email delivery guard (#114)** — outgoing email, SMTP connection tests, and queue processing are blocked when WordPress reports a `local` environment or the site uses a common local-development hostname. Administrators see a persistent warning on Mail System pages, and detection remains filterable for project-specific setups.
 - **Secure email click analytics (#113)**
   - Rewrites eligible campaign and one-time email links through HMAC-signed, recipient-specific redirect URLs
@@ -314,7 +324,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Minor** (0.X.0) - New features, backward compatible
 - **Patch** (0.0.X) - Bug fixes, backward compatible
 
-[Unreleased]: https://github.com/katsarov-design/mail-system/compare/1.1.1...HEAD
+[Unreleased]: https://github.com/katsarov-design/mail-system/compare/1.1.2...HEAD
+[1.1.2]: https://github.com/katsarov-design/mail-system/compare/1.1.1...1.1.2
 [1.1.1]: https://github.com/katsarov-design/mail-system/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/katsarov-design/mail-system/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/katsarov-design/mail-system/releases/tag/1.0.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version 1.1.1" src="https://img.shields.io/badge/version-1.1.1-1f6feb?style=for-the-badge">
+  <img alt="Version 1.1.2" src="https://img.shields.io/badge/version-1.1.2-1f6feb?style=for-the-badge">
   <img alt="WordPress 5.0+" src="https://img.shields.io/badge/WordPress-5.0%2B-21759b?style=for-the-badge&logo=wordpress&logoColor=white">
   <img alt="PHP 7.4+" src="https://img.shields.io/badge/PHP-7.4%2B-777bb4?style=for-the-badge&logo=php&logoColor=white">
   <img alt="License GPL-2.0-or-later" src="https://img.shields.io/badge/license-GPL--2.0--or--later-0f766e?style=for-the-badge">

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -756,7 +756,7 @@ add_action( 'mskd_subscriber_unsubscribed', function( $email, $token ) {
 
 | Constant | Default | Description |
 |----------|---------|-------------|
-| `MSKD_VERSION` | `1.1.0` | Plugin version |
+| `MSKD_VERSION` | `1.1.2` | Plugin version |
 | `MSKD_BATCH_SIZE` | `10` | Emails per cron run (configurable via settings) |
 | `MSKD_PLUGIN_DIR` | — | Plugin directory path |
 | `MSKD_PLUGIN_URL` | — | Plugin URL |

--- a/docs/index.html
+++ b/docs/index.html
@@ -50,7 +50,7 @@
                 <div class="hero-grid">
                     <div class="hero-content">
                         <div class="badges">
-                            <span class="badge badge-version">Version 1.1.1</span>
+                            <span class="badge badge-version">Version 1.1.2</span>
                             <span class="badge badge-wp">WordPress 5.0+</span>
                             <span class="badge badge-php">PHP 7.4+</span>
                             <span class="badge badge-license">GPL v2</span>

--- a/mail-system.php
+++ b/mail-system.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Mail System by Katsarov Design
  * Plugin URI:        https://katsarov.design/plugins/mail-system
  * Description:       Email newsletter management system with subscribers, lists, and sending queue.
- * Version:           1.1.1
+ * Version:           1.1.2
  * Requires at least: 5.0
  * Requires PHP:      7.4
  * Author:            Katsarov Design
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Plugin constants
  */
-define( 'MSKD_VERSION', '1.1.1' );
+define( 'MSKD_VERSION', '1.1.2' );
 define( 'MSKD_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'MSKD_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'MSKD_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mail-system",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mail-system",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "sass": "^1.69.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail-system",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "WordPress Mail System Plugin by Katsarov Design",
   "main": "mail-system.php",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: katsarovdesign
 Tags: email, newsletter, mailing list, subscribers, bulgarian, български
 Requires at least: 5.0
 Tested up to: 6.4
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -89,6 +89,11 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 6. Настройки
 
 == Changelog ==
+
+= 1.1.2 =
+* Анализ на отваряния и кликвания в имейли с защита на личните данни
+* Защита срещу изпращане на имейли в локална среда
+* Подобрения в опашката, потвърждението за абонамент и SMTP криптирането
 
 = 1.1.1 =
 * Поправен проблем с липсващ превод за "Общо абонати"


### PR DESCRIPTION
## Release v1.1.2

- Adds local email delivery safeguards and open/click analytics.
- Includes queue, preview, opt-in, SMTP encryption, subscriber-action, and database-repair fixes.
- Bumps all published plugin and package metadata to 1.1.2.

Validation: 232 PHPUnit tests and PHPCS passed; production CSS and visual-editor builds succeeded.