### PR TITLE
fix(queue): prevent Subject column from collapsing to zero width

### DIFF
--- a/admin/partials/queue-legacy.php
+++ b/admin/partials/queue-legacy.php
@@ -114,12 +114,13 @@ $queue_items = $wpdb->get_results(
 		</li>
 	</ul>
 
-	<table class="wp-list-table widefat fixed striped">
+	<div class="mskd-table-responsive">
+	<table class="wp-list-table widefat striped mskd-queue-table">
 		<thead>
 			<tr>
 				<th scope="col" style="width: 50px;"><?php esc_html_e( 'ID', 'mail-system' ); ?></th>
 				<th scope="col"><?php esc_html_e( 'Recipient', 'mail-system' ); ?></th>
-				<th scope="col"><?php esc_html_e( 'Subject', 'mail-system' ); ?></th>
+				<th scope="col" class="mskd-col-subject"><?php esc_html_e( 'Subject', 'mail-system' ); ?></th>
 				<th scope="col" style="width: 100px;"><?php esc_html_e( 'Status', 'mail-system' ); ?></th>
 				<th scope="col" style="width: 80px;"><?php esc_html_e( 'Attempts', 'mail-system' ); ?></th>
 				<th scope="col"><?php esc_html_e( 'Scheduled', 'mail-system' ); ?></th>
@@ -161,7 +162,7 @@ $queue_items = $wpdb->get_results(
 								<em><?php esc_html_e( 'Deleted subscriber', 'mail-system' ); ?></em>
 							<?php endif; ?>
 						</td>
-						<td><?php echo esc_html( $item->subject ); ?></td>
+						<td class="mskd-subject-cell"><?php echo esc_html( $item->subject ); ?></td>
 						<td>
 							<span class="mskd-status mskd-status-<?php echo esc_attr( $item->status ); ?>">
 								<?php
@@ -230,6 +231,7 @@ $queue_items = $wpdb->get_results(
 			<?php endif; ?>
 		</tbody>
 	</table>
+	</div>
 
 	<!-- Pagination -->
 	<?php if ( $total_pages > 1 ) : ?>

--- a/admin/partials/queue.php
+++ b/admin/partials/queue.php
@@ -230,11 +230,12 @@ $emails_per_minute = isset( $settings['emails_per_minute'] ) ? absint( $settings
 		</div>
 	<?php endif; ?>
 
-	<table class="wp-list-table widefat fixed striped">
+	<div class="mskd-table-responsive">
+	<table class="wp-list-table widefat striped mskd-queue-table">
 		<thead>
 			<tr>
 				<th scope="col" style="width: 50px;"><?php esc_html_e( 'ID', 'mail-system' ); ?></th>
-				<th scope="col"><?php esc_html_e( 'Subject', 'mail-system' ); ?></th>
+				<th scope="col" class="mskd-col-subject"><?php esc_html_e( 'Subject', 'mail-system' ); ?></th>
 				<th scope="col" style="width: 100px;"><?php esc_html_e( 'Type', 'mail-system' ); ?></th>
 				<th scope="col" style="width: 100px;"><?php esc_html_e( 'Recipients', 'mail-system' ); ?></th>
 				<th scope="col" style="width: 180px;"><?php esc_html_e( 'Progress', 'mail-system' ); ?></th>
@@ -273,7 +274,7 @@ $emails_per_minute = isset( $settings['emails_per_minute'] ) ? absint( $settings
 					?>
 					<tr>
 						<td><?php echo esc_html( $campaign->id ); ?></td>
-						<td>
+						<td class="mskd-subject-cell">
 							<a href="<?php echo esc_url( admin_url( 'admin.php?page=mskd-queue&action=view&campaign_id=' . $campaign->id ) ); ?>">
 								<strong><?php echo esc_html( $campaign->subject ); ?></strong>
 							</a>
@@ -398,6 +399,7 @@ $emails_per_minute = isset( $settings['emails_per_minute'] ) ? absint( $settings
 			<?php endif; ?>
 		</tbody>
 	</table>
+	</div>
 
 	<!-- Pagination -->
 	<?php if ( $total_pages > 1 ) : ?>

--- a/admin/scss/components/_queue.scss
+++ b/admin/scss/components/_queue.scss
@@ -70,6 +70,32 @@
   margin-top: 4px;
 }
 
+// Queue tables
+.mskd-table-responsive {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.mskd-queue-table {
+  min-width: 100%;
+
+  .mskd-col-subject {
+    width: 100%;
+    min-width: 220px;
+  }
+
+  .mskd-subject-cell {
+    min-width: 220px;
+    word-break: normal;
+    overflow-wrap: anywhere;
+
+    a {
+      display: inline-block;
+      max-width: 100%;
+    }
+  }
+}
+
 // Campaign Type Badges
 .mskd-badge-onetime {
   background: $color-info-bg;


### PR DESCRIPTION
## Summary

Fixes #120.

On the Sending queue admin page the Subject (Тема) column was collapsing to a near-zero width because the table used WordPress' `fixed` class (`table-layout: fixed`) while every other column had an explicit pixel width. The only flexible column (Subject) was squeezed to its minimum content width, causing Bulgarian subject text to wrap one character per line.

## Changes

- Removed `fixed` from the queue table classes and wrapped each table in `.mskd-table-responsive` so the Subject column can absorb remaining space and the table scrolls horizontally on narrow viewports.
- Added `.mskd-col-subject` to the Subject header and `.mskd-subject-cell` to Subject cells.
- Added SCSS rules giving the Subject column `width: 100%` and a `220px` minimum width, plus `word-break: normal` / `overflow-wrap: anywhere` to avoid per-character breaking.
- Applied the same fix to both `admin/partials/queue.php` and `admin/partials/queue-legacy.php`.

## Verification

- `composer phpcs` passes on the changed PHP files.
- `composer test:unit` passes (232 tests, 500 assertions).
- `npm run sass:build` compiles successfully and the generated CSS contains the new selectors.
