### PR TITLE
feat: use full width in wp-admin by removing max-width on mskd-wrap (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The compose controller now delegates recipient resolution, Bcc validation and scheduling to the shared `Campaign_Service` rather than duplicating that logic.
 
 ### Fixed
+- **Full-width admin queue layout (#122)** — the queue table now clears the floated status filters and uses the available WordPress admin content width without forcing page-level horizontal scrolling.
 - **Fresh-install schema drift** — a brand-new installation's campaigns table was missing the `bcc`, `bcc_sent`, `from_email`, and `from_name` columns that every campaign insert expects, and the queue `status` enum omitted the `cancelled` state that cancellation code writes. The canonical schema now includes them, and an upgrade path (schema version 1.9.0) repairs existing installs.
 
 ### Security

--- a/admin/scss/base/_base.scss
+++ b/admin/scss/base/_base.scss
@@ -7,5 +7,5 @@
 
 // General wrapper
 .mskd-wrap {
-  max-width: $container-max-width;
+  width: 100%;
 }

--- a/admin/scss/base/_base.scss
+++ b/admin/scss/base/_base.scss
@@ -7,5 +7,5 @@
 
 // General wrapper
 .mskd-wrap {
-  width: 100%;
+  width: auto;
 }

--- a/admin/scss/components/_queue.scss
+++ b/admin/scss/components/_queue.scss
@@ -72,6 +72,8 @@
 
 // Queue tables
 .mskd-table-responsive {
+  clear: both;
+  width: 100%;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
 }

--- a/admin/scss/components/_queue.scss
+++ b/admin/scss/components/_queue.scss
@@ -79,15 +79,14 @@
 }
 
 .mskd-queue-table {
+  width: 100%;
   min-width: 100%;
 
   .mskd-col-subject {
-    width: 100%;
-    min-width: 220px;
+    width: auto;
   }
 
   .mskd-subject-cell {
-    min-width: 220px;
     word-break: normal;
     overflow-wrap: anywhere;
 


### PR DESCRIPTION
Closes #122

### Summary
This PR removes the `max-width: $container-max-width;` restriction on the `.mskd-wrap` container class, allowing the plugin's admin interface (dashboard, subscriber lists, mail queue, etc.) to occupy the full width of the available wp-admin content area on larger viewports.

### Changes
- Updated `admin/scss/base/_base.scss` to use `width: 100%` instead of `max-width: $container-max-width;` on `.mskd-wrap`.