### PR TITLE
fix(queue): align headings below status filters on campaign detail

### DIFF
--- a/admin/partials/queue-detail.php
+++ b/admin/partials/queue-detail.php
@@ -371,6 +371,7 @@ $can_cancel = in_array( $campaign->status, array( 'pending', 'processing' ), tru
 			</a>
 		</li>
 	</ul>
+	<br class="clear">
 
 	<?php if ( ! empty( $link_stats ) ) : ?>
 		<h2><?php esc_html_e( 'Link performance', 'mail-system' ); ?></h2>


### PR DESCRIPTION
## Problem

On the campaign detail page (`admin/partials/queue-detail.php`), the **Link performance** / **Recipients** heading rendered vertically misaligned — pulled up next to the status-filter links (All / Sent / Cancelled …) instead of sitting below them.

![alignment issue](heading floats up beside the Успешни/Отменени filters)

## Cause

The `<ul class="subsubsub">` status-filter list is floated left by WordPress core admin styles. Nothing cleared that float, so the next block-level element (the first `<h2>` after the list) wrapped up alongside the floated filters.

## Fix

Add `<br class="clear">` immediately after the filter list — the same pattern WordPress core list tables use. `.clear { clear: both; }` is provided by WP admin CSS on every admin page, so no SCSS rebuild is needed. This covers both cases: when link stats are present ("Link performance" heading) and when they aren't ("Recipients" heading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)